### PR TITLE
Add background clearing fix for tmux

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,5 @@
 set nocompatible      " We're running Vim, not Vi!
+set t_ut=             " Clearing screen loads current bg color (tmux fix)
 
 colorschem summerfruit256
 


### PR DESCRIPTION
Hey Anthony,
I watched some of your video's on youtube. I realized we have very similar workflows, so I checked out your dotfiles. They're great! Anyway, I noticed a little quickfix that might help you. This makes sure vim fills up the background when running in tmux. I forked your dotfiles and tried it on my machine, it should work.
Cheers!
Signed-off-by: Yann Vanhalewyn yann_vanhalewyn@hotmail.com
